### PR TITLE
增强 runtime join on 动态条件的防护

### DIFF
--- a/src/main/java/cn/beagile/dslquery/ColumnFields.java
+++ b/src/main/java/cn/beagile/dslquery/ColumnFields.java
@@ -22,6 +22,7 @@ public class ColumnFields {
         initSelectIgnores(this.clz);
         initDeepJoins(this.clz);
         readFields(this.clz);
+        validateRuntimeJoinOnPaths();
     }
 
     private <T> void readFields(Class<T> clz) {
@@ -82,6 +83,20 @@ public class ColumnFields {
     private void readJoins(Class clz, List<Field> parents) {
         readJoinFields(clz, parents, JoinColumn.class);
         readJoinFields(clz, parents, JoinColumns.class);
+    }
+
+    private void validateRuntimeJoinOnPaths() {
+        Set<String> runtimeJoinOnPaths = Optional.ofNullable(dslQuery)
+                .map(DSLQuery::getJoinOns)
+                .map(Map::keySet)
+                .orElse(Collections.emptySet());
+        Set<String> joinedPaths = joinFields.stream().map(JoinField::parentNames).collect(Collectors.toSet());
+        runtimeJoinOnPaths.stream()
+                .filter(path -> !joinedPaths.contains(path))
+                .findFirst()
+                .ifPresent(path -> {
+                    throw new RuntimeException("join path not found: " + path);
+                });
     }
 
     private boolean isJoinInclude(Field field, List<Field> parents) {

--- a/src/main/java/cn/beagile/dslquery/DSLQuery.java
+++ b/src/main/java/cn/beagile/dslquery/DSLQuery.java
@@ -132,6 +132,7 @@ public class DSLQuery<T> {
         if (path == null || path.isEmpty() || dsl == null || dsl.isEmpty()) {
             return this;
         }
+        Validators.validateJoinPath(path);
         joinOns.computeIfAbsent(path, key -> new ArrayList<>()).add(dsl);
         return this;
     }

--- a/src/main/java/cn/beagile/dslquery/JoinOnSQLBuilder.java
+++ b/src/main/java/cn/beagile/dslquery/JoinOnSQLBuilder.java
@@ -13,6 +13,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class JoinOnSQLBuilder implements SQLBuilder {
+    private static final int MAX_JOIN_ON_EXPRESSION_LENGTH = 2048;
+    private static final int MAX_JOIN_ON_NESTING_DEPTH = 10;
     private final Map<String, ColumnField> fields = new LinkedHashMap<>();
     private final Map<String, Object> params;
     private final String paramPrefix;
@@ -31,9 +33,31 @@ class JoinOnSQLBuilder implements SQLBuilder {
         }
         WhereParser parser = new WhereParser();
         return joinOns.stream()
+                .peek(this::validateJoinOn)
                 .map(parser::parse)
                 .map(expression -> expression.toSQL(this))
                 .collect(Collectors.joining(" and "));
+    }
+
+    private void validateJoinOn(String joinOn) {
+        if (joinOn.length() > MAX_JOIN_ON_EXPRESSION_LENGTH) {
+            throw new RuntimeException("join on expression too long");
+        }
+        int depth = 0;
+        int maxDepth = 0;
+        for (int i = 0; i < joinOn.length(); i++) {
+            char ch = joinOn.charAt(i);
+            if (ch == '(') {
+                depth++;
+                maxDepth = Math.max(maxDepth, depth);
+            }
+            if (ch == ')') {
+                depth--;
+            }
+        }
+        if (maxDepth > MAX_JOIN_ON_NESTING_DEPTH) {
+            throw new RuntimeException("join on nesting too deep");
+        }
     }
 
     private void initFields(Field joinField, List<Field> parents) {

--- a/src/main/java/cn/beagile/dslquery/Validators.java
+++ b/src/main/java/cn/beagile/dslquery/Validators.java
@@ -9,4 +9,11 @@ interface Validators {
             throw new RuntimeException("invalid field:" + field);
         }
     }
+
+    static void validateJoinPath(String path) {
+        Pattern validJoinPathPattern = Pattern.compile("[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*$");
+        if (!validJoinPathPattern.matcher(path).matches()) {
+            throw new RuntimeException("invalid join path:" + path);
+        }
+    }
 }

--- a/src/test/java/cn/beagile/dslquery/JoinOnQueryTest.java
+++ b/src/test/java/cn/beagile/dslquery/JoinOnQueryTest.java
@@ -113,4 +113,47 @@ class JoinOnQueryTest {
         RuntimeException exception = assertThrows(RuntimeException.class, () -> sqlBuilder.build(nullsOrder));
         assertEquals("field not found: missing", exception.getMessage());
     }
+
+    @Test
+    void should_reject_invalid_runtime_join_on_path() {
+        DSLQuery<User> dslQuery = new DSLQuery<>(null, User.class);
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> dslQuery.joinOn("org;drop", "(and(type eq SALES))"));
+
+        assertEquals("invalid join path:org;drop", exception.getMessage());
+    }
+
+    @Test
+    void should_fail_when_runtime_join_on_path_is_not_joined() {
+        DSLQuery<User> dslQuery = new DSLQuery<>(null, User.class)
+                .joinOn("org.area", "(and(active eq true))");
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> new DSLSQLBuilder<>(dslQuery).build(nullsOrder));
+        assertEquals("join path not found: org.area", exception.getMessage());
+    }
+
+    @Test
+    void should_fail_when_join_on_expression_is_too_deep() {
+        DSLQuery<User> dslQuery = new DSLQuery<>(null, User.class)
+                .joinOn("org", "(and(or(and(or(and(or(and(or(and(or(and(type eq SALES))))))))))))");
+
+        DSLSQLBuilder<User> sqlBuilder = new DSLSQLBuilder<>(dslQuery);
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> sqlBuilder.build(nullsOrder));
+        assertEquals("join on nesting too deep", exception.getMessage());
+    }
+
+    @Test
+    void should_fail_when_join_on_expression_is_too_long() {
+        String longValue = "a".repeat(2050);
+        DSLQuery<User> dslQuery = new DSLQuery<>(null, User.class)
+                .joinOn("org", "(and(type eq " + longValue + "))");
+
+        DSLSQLBuilder<User> sqlBuilder = new DSLSQLBuilder<>(dslQuery);
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> sqlBuilder.build(nullsOrder));
+        assertEquals("join on expression too long", exception.getMessage());
+    }
 }


### PR DESCRIPTION
## 变更说明

这个 PR 是对已合并的 join-on scoped DSL 功能做一轮小范围 hardening，主要补 runtime 动态传入场景下的防护，不引入新的 DSL 语义。

### 本次补充的防护

- 对 `DSLQuery.joinOn(path, dsl)` 的 `path` 做格式校验，非法路径直接 fail fast
- 对 runtime `joinOn` 的路径做命中校验，避免条件挂到不存在的 join 路径上时静默失效
- 对 join-on DSL 增加输入边界保护：
  - 最大长度 `2048`
  - 最大嵌套深度 `10`

### 设计原则

- 只加防护，不扩能力
- 保持现有 scoped DSL 语义不变
- 保持正常使用场景的 SQL 生成结果不变
- 对错误输入优先 fail fast，而不是静默忽略

### 测试

新增覆盖以下场景：

- 非法 runtime join-on path
- runtime join-on path 未命中实际 join
- join-on DSL 嵌套过深
- join-on DSL 过长

## 验证

已执行：

```bash
gradle -I /tmp/gradle8-jacoco-compat.init.gradle test
```

结果：

- `BUILD SUCCESSFUL`
